### PR TITLE
Menagerie register

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,12 @@ The project runs on the Pi using [Hypriot's][1] docker image.
 * NODE_APP_FLOOR
 * NODE_APP_BUILDING
 
-* NODE_DEVICE_UUID 
+* NODE_DEVICE_UUID
+
+* NODE_AGENT_ENDPOINT
+* NODE_AGNET_TOKEN
+* NODE_AGENT_METADATA
+* NODE_DEVICE_TYPE_NAME
 
 Note on environment variables, if you add them to the Dockerfile, it seems to slow down the build process as it has to make a new layer per env var(?!)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 ### Raspberry Pi PIR 
 Simple PoC to collect motion data using Raspberry Pi's.
 
+Flow:
+
+- Develop in your computer.
+- Have RPi with `git` and `docker` installed.
+- Build `github.com/goliatone/rpi-pir-sensor` in your pi.
+- Push image to docker hub.
+
+Currently we are using ssh remote commands to deploy new sensor instances. In the future we want to have a `docker` cluster where you can remotely push 
+
+## Deployment
+
 ## Development
 
 You can use `envset` to manage a development environment local to your [Mac] computer. For production, if you don't want to install node in the Pi to run `envset` you can export environmental variables in a script before running your docker instance.
@@ -19,11 +30,12 @@ The project runs on the Pi using [Hypriot's][1] docker image.
 * NODE_RPI_ID
 * NODE_RPI_GPIO
 * NODE_RPI_ARCH
+* NODE_RPI_REPL
 
-* NODE_INFLUX_HOST
-* *NODE_INFLUX_PORT
 * NODE_INFLUX_USER
 * NODE_INFLUX_PASS
+* NODE_INFLUX_HOST
+* NODE_INFLUX_PORT
 * NODE_INFLUX_DATABASE
 * NODE_INFLUX_PROTOCOL
 * NODE_INFLUX_SERIES_NAME
@@ -36,8 +48,8 @@ The project runs on the Pi using [Hypriot's][1] docker image.
 
 * NODE_DEVICE_UUID
 
+* NODE_AGENT_TOKEN
 * NODE_AGENT_ENDPOINT
-* NODE_AGNET_TOKEN
 * NODE_AGENT_METADATA
 * NODE_DEVICE_TYPE_NAME
 
@@ -51,6 +63,24 @@ To open a shell session:
 ```
 docker run -t -i --rm --privileged --cap-add=ALL -v /lib/modules:/lib/modules -v /dev:/dev rpi-pir-sensor /bin/bash
 ```
+
+
+#### OPS
+The `ops` directory contains a set of commands to interact with docker. 
+
+We build a docker image on a raspberry pi and push the image to docker hub. In order to do so, we need to have credentials on the pi. You can simply `docker login` in your computer:
+
+```
+$ docker login --password=Password --username=Username
+```
+
+Then you can copy the generated token and place it in the raspberry pi. The token is found at `~/.docker/config.json `. You should place it on the same path.
+
+The `docker-push` will send a built image to a docker hub repository.
+
+<!--
+`https://hub.docker.com/r/goliatone/rpi-pir-sensor/`
+-->
 
 ### InfluxDB
 
@@ -113,6 +143,7 @@ To get MAC address:
 ```
 cat /sys/class/net/eth0/address
 ```
+
 
 ### TODO
 

--- a/agent/index.js
+++ b/agent/index.js
@@ -22,8 +22,6 @@ module.exports.init = function(config, options){
     };
 
     request.post(payload, function(err, httResponse, body){
-        console.log('err', err);
-        console.log('response', httResponse);
-        console.log('body', body);
+        if(err) console.error('ERROR', err);
     });
 };

--- a/agent/index.js
+++ b/agent/index.js
@@ -1,0 +1,35 @@
+'use strict';
+var extend = require('gextend');
+var request = require('request');
+
+module.exports.init = function(config, options){
+
+    if(config.metadata) {
+        try {
+            var meta = JSON.parse(config.metadata);
+            var merged = extend({}, config.payload.metadata, meta);
+            config.payload.metadata = merged;
+        } catch(e){}
+    }
+
+    config.url = (config.url + '').replace(/\/+$/, '') + '/' + config.payload.uuid;
+    var access_token = config.token;
+
+    delete config.token;
+    delete config.metadata;
+
+    return console.log('REGISTERING', JSON.stringify(config, null, 4));
+
+    request.post({
+        url: config.url,
+        qs: {access_token: access_token}
+    },{
+        form: {
+            id: config.id,
+            uuid: config.uuid,
+            status: config.status,
+            typeName: config.typeName,
+            metadata: config.payload.metadata,
+        }
+    });
+};

--- a/agent/index.js
+++ b/agent/index.js
@@ -1,6 +1,8 @@
 'use strict';
+
 var extend = require('gextend');
 var request = require('request');
+var debug = require('debug')('sensor:agent');
 
 module.exports.init = function(config, options){
 
@@ -13,6 +15,9 @@ module.exports.init = function(config, options){
     }
 
     config.url = (config.url + '').replace(/\/+$/, '') + '/' + config.payload.uuid;
+
+    debug('agent: Registering device with url %s', config.url);
+
     var accessToken = config.token;
 
     var payload = {
@@ -23,5 +28,6 @@ module.exports.init = function(config, options){
 
     request.post(payload, function(err, httResponse, body){
         if(err) console.error('ERROR', err);
+        debug('agent: device registration payload sent.');
     });
 };

--- a/agent/index.js
+++ b/agent/index.js
@@ -13,23 +13,17 @@ module.exports.init = function(config, options){
     }
 
     config.url = (config.url + '').replace(/\/+$/, '') + '/' + config.payload.uuid;
-    var access_token = config.token;
+    var accessToken = config.token;
 
-    delete config.token;
-    delete config.metadata;
+    var payload = {
+        uri: config.url,
+        qs: { 'access_token': accessToken},
+        form: config.payload
+    };
 
-    return console.log('REGISTERING', JSON.stringify(config, null, 4));
-
-    request.post({
-        url: config.url,
-        qs: {access_token: access_token}
-    },{
-        form: {
-            id: config.id,
-            uuid: config.uuid,
-            status: config.status,
-            typeName: config.typeName,
-            metadata: config.payload.metadata,
-        }
+    request.post(payload, function(err, httResponse, body){
+        console.log('err', err);
+        console.log('response', httResponse);
+        console.log('body', body);
     });
 };

--- a/agent/index.js
+++ b/agent/index.js
@@ -16,7 +16,7 @@ module.exports.init = function(config, options){
 
     config.url = (config.url + '').replace(/\/+$/, '') + '/' + config.payload.uuid;
 
-    debug('agent: Registering device with url %s', config.url);
+    console.log('agent: Registering device with url %s', config.url);
 
     var accessToken = config.token;
 
@@ -28,6 +28,6 @@ module.exports.init = function(config, options){
 
     request.post(payload, function(err, httResponse, body){
         if(err) console.error('ERROR', err);
-        debug('agent: device registration payload sent.');
+        console.log('agent: device registration payload sent.');
     });
 };

--- a/bin/daemon
+++ b/bin/daemon
@@ -7,19 +7,32 @@ var reporter = require('../reporter');
 var server = require('../server').createServer();
 var agent = require('../agent');
 
+var extend = require('gextend');
+
 /*
  * Initialize menagerie agent.
  */
 agent.init(config.agent, config);
 
+/*
+ * Initialize reporter.
+ * Reporter sends sensor data to
+ * different endpoints. In this
+ * case, InlfuxDB.
+ */
 reporter.init(config.reporter);
 
 
 console.log('config');
 console.log(JSON.stringify(config, null, 4));
 
-//Server: We should be able to change configuration on
-//GUI/Client and then reboot app.
+/*
+ * We run a small server instance that
+ * provides a GUI.
+ *
+ * TODO: Ideally we would like to have this
+ * as a separate process (docker image?)
+ */
 server.start().on('server.ready', function(){
     /*
      * Sensor uses app to publish events.
@@ -27,6 +40,10 @@ server.start().on('server.ready', function(){
     sensor.init(server, config.sensor);
 });
 
+/*
+ * We register an event listener for sensor
+ * events.
+ */
 server.on('sensor.event', function(event){
     console.warn('sensor.event', event);
 
@@ -42,8 +59,6 @@ server.on('sensor.event', function(event){
     reporter.buffer(payload);
 });
 
-
-var extend = require('gextend');
 function getPayload(values, tags, defaults){
     var out = extend({}, defaults, tags);
     return [values, out];

--- a/bin/daemon
+++ b/bin/daemon
@@ -5,8 +5,15 @@ var sensor = require('../sensor');
 var config = require('../config');
 var reporter = require('../reporter');
 var server = require('../server').createServer();
+var agent = require('../agent');
+
+/*
+ * Initialize menagerie agent.
+ */
+agent.init(config.agent, config);
 
 reporter.init(config.reporter);
+
 
 console.log('config');
 console.log(JSON.stringify(config, null, 4));

--- a/config/index.js
+++ b/config/index.js
@@ -28,9 +28,7 @@ module.exports = {
             'id': process.env.NODE_RPI_ID,
             'typeName': process.env.NODE_DEVICE_TYPE_NAME,
             'status': 'inuse',
-            'metadata': {
-
-            }
+            'metadata': {}
         }
     },
     reporter: {

--- a/config/index.js
+++ b/config/index.js
@@ -25,8 +25,9 @@ module.exports = {
         metadata: process.env.NODE_AGENT_METADATA,
         payload: {
             'uuid': uuidGenerator(process.env.NODE_DEVICE_UUID),
-            'id': process.env.NODE_RPI_ID,
+            'name': process.env.NODE_RPI_ID,
             'typeName': process.env.NODE_DEVICE_TYPE_NAME,
+            // 'type': 1,
             'status': 'inuse',
             'metadata': {}
         }

--- a/config/index.js
+++ b/config/index.js
@@ -7,7 +7,7 @@ var uuidGenerator = require('singleton-uuid');
 //TODO: We should load cached version of updated props.
 //TODO: We should be getting config from menagerie
 module.exports = {
-    sensor:{
+    sensor: {
         //Should we use uuid?
         id: process.env.NODE_RPI_ID,
         gpio: process.env.NODE_RPI_GPIO || 'GPIO21'
@@ -15,8 +15,22 @@ module.exports = {
     device: {
         uuid: uuidGenerator(process.env.NODE_DEVICE_UUID),
         config: {
-            building: '_unset_',
-            floor: '_unset_'
+            building: process.env.NODE_APP_BUILDING,
+            floor: process.env.NODE_APP_FLOOR
+        }
+    },
+    agent: {
+        url: process.env.NODE_AGENT_ENDPOINT,
+        token: process.env.NODE_AGNET_TOKEN,
+        metadata: process.env.NODE_AGENT_METADATA,
+        payload: {
+            'uuid': uuidGenerator(process.env.NODE_DEVICE_UUID),
+            'id': process.env.NODE_RPI_ID,
+            'typeName': process.env.NODE_DEVICE_TYPE_NAME,
+            'status': 'inuse',
+            'metadata': {
+
+            }
         }
     },
     reporter: {

--- a/config/index.js
+++ b/config/index.js
@@ -21,7 +21,7 @@ module.exports = {
     },
     agent: {
         url: process.env.NODE_AGENT_ENDPOINT,
-        token: process.env.NODE_AGNET_TOKEN,
+        token: process.env.NODE_AGENT_TOKEN,
         metadata: process.env.NODE_AGENT_METADATA,
         payload: {
             'uuid': uuidGenerator(process.env.NODE_DEVICE_UUID),

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "johnny-five": "^0.9.19",
     "morgan": "~1.5.1",
     "raspi-io": "^5.2.0",
+    "request": "^2.69.0",
     "serve-favicon": "~2.2.0",
     "singleton-uuid": "^0.1.0"
   }


### PR DESCRIPTION
Adds registration `agent` and flow. The agent will register the device with a service to track app status- we are initially using [menagerie](https://github.com/goliatone/menagerie) but could be expanded to use something different in the future.

We added some environmental variables:
- NODE_AGENT_TOKEN
- NODE_AGENT_ENDPOINT
- NODE_AGENT_METADATA
- NODE_DEVICE_TYPE_NAME

Metadata can be used to store a json string that can be consumed by the `agent`. We are interested in storing information like the hosts raspberry pi IP, etc.
