### PR TITLE
Docker fix deploy cycle

### DIFF
--- a/ops/publish-remote
+++ b/ops/publish-remote
@@ -9,4 +9,4 @@ echo "docker build goliatone/rpi-pir-sensor..."
 docker build --rm -t goliatone/rpi-pir-sensor .
 
 echo "docker push goliatone/rpi-pir-sensor..."
-docker push goliatone/rpi-pir-sensor
+docker push goliatone/rpi-pir-sensor:latest

--- a/ops/update-instance
+++ b/ops/update-instance
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Pull goliatone/rpi-pir-sensor..."
-docker pull goliatone/rpi-pir-sensor
+docker pull goliatone/rpi-pir-sensor:latest
 
 echo "docker stop wee-sensor..."
 ! docker stop wee-sensor
@@ -9,8 +9,8 @@ echo "docker stop wee-sensor..."
 echo "docker remove old images..."
 ! docker rm -v $(docker ps -a -q -f status=exited)
 
-echo "dokcer remove dangling images..."
+echo "docker remove dangling images..."
 ! docker rmi $(docker images -f "dangling=true" -q)
 
 echo "docker run..."
-docker run --name=wee-sensor --env-file .env -v /dev/mem:/dev/mem -v /lib/modules:/lib/modules --cap-add=ALL --privileged -p 3000:3000 --restart=always -d goliatone/rpi-pir-sensor
+docker run --name=wee-sensor --env-file .env -v /dev/mem:/dev/mem -v /lib/modules:/lib/modules --cap-add=ALL --privileged -p 3000:3000 --restart=always -d goliatone/rpi-pir-sensor:latest


### PR DESCRIPTION
This closes #23, where docker images built on client sensor RPi's did not have the latest source code we had upstream.

Added `latest` tag to `ops/publish-remote`, and then we pull from the `latest` tag as well in `ops/update-instance`
