### PR TITLE
ops: rpi-update adding context flag, passed on to slv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ node_modules
 .env
 .*env
 ops/env-files/*
+ops/context/*.json

--- a/ops/rpi-update
+++ b/ops/rpi-update
@@ -17,7 +17,7 @@ program
     .version(pkg.version)
     .option('-e, --environment <environment>', 'Environment to pull variables from')
     .option('-h, --hostname <hostname>', 'Instance hostname name')
-    .option('-C, --context-path <context-path>', 'Context path to look for a hostname .json file with extra arguments for the template', false)
+    .option('-C, --context-path <context-path>', 'We can pass either a path to a json file or a path to a directory with json files named after the hostname.', false)
     .option('-d, --dry-run', 'Just display cmds but do not run them')
     .parse(process.argv);
 

--- a/ops/rpi-update
+++ b/ops/rpi-update
@@ -4,6 +4,8 @@
 
 var program = require('commander');
 var pkg = require('../package.json');
+var join = require('path').join;
+var resolve = require('path').resolve;
 var template = require('./utils/template');
 
 var exec = require('child_process').execSync;
@@ -15,6 +17,8 @@ program
     .version(pkg.version)
     .option('-e, --environment <environment>', 'Environment to pull variables from')
     .option('-h, --hostname <hostname>', 'Instance hostname name')
+    .option('-C, --context-path <context-path>', 'Context path to look for a hostname .json file with extra arguments for the template', false)
+    .option('-d, --dry-run', 'Just display cmds but do not run them')
     .parse(process.argv);
 
 if(!program.environment || !program.hostname){
@@ -23,24 +27,33 @@ if(!program.environment || !program.hostname){
     process.exit(0);
 }
 
+
+var contextpath = false;
+
+if(program.contextPath){
+    contextpath = resolve(program.contextPath);
+    if(contextpath.indexOf('.json') === -1) contextpath = join(contextpath, program.hostname + '.json');
+}
+
 var context = {
     filepath: './',
     filename: '.' + program.hostname + '-env',
     scripts: __dirname,
     hostname: program.hostname,
     environment: program.environment,
-    envfile: require('path').join( __dirname, 'env-files', '.env-' + program.hostname)
+    contextpath: contextpath,
+    envfile: join( __dirname, 'env-files', '.env-' + program.hostname)
 };
 
 //console.log(context)
 
 var tpls = [
     //create env file based on environment and instance
-    'NODE_RPI_ID={{hostname}} envset {{environment}} -- slv {{scripts}}/templates/env.tpl > {{envfile}}',
+    'NODE_RPI_ID={{hostname}} envset {{environment}} -- slv -c={{contextpath}} {{scripts}}/templates/env.tpl > {{envfile}}',
     //copy env file to destination rpi
-    'time scp {{envfile}} root@{{hostname}}.local:/root/.env',
+    //'time scp {{envfile}} root@{{hostname}}.local:/root/.env',
     //update remote instance
-    'time cat {{scripts}}/update-instance | ssh root@{{hostname}}.local /bin/bash'
+    //'time cat {{scripts}}/update-instance | ssh root@{{hostname}}.local /bin/bash'
 ];
 
 var cmds = [];
@@ -51,6 +64,6 @@ tpls.map(function(tpl){
 
 //TODO: We need to capture output in a sane way
 cmds.map(function(cmd){
+    if(program.dryRun) return console.log(cmd);
     var out = exec(cmd, {stdio: [0, 1, 2]});
 });
-


### PR DESCRIPTION
This closes #30, so we can specify a context file path that will get sent to `slv`. We can put instance specific variables, which currently does not work so well using only `envset`.

We can pass either a path to a json file or a path to a directory with json files named after the hostname.
