### PR TITLE
package: Use forked raspi-io and raspi-led

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "influx": "^4.1.0",
     "johnny-five": "^0.9.19",
     "morgan": "~1.5.1",
-    "raspi-io": "^5.2.0",
+    "raspi-io": "goliatone/raspi-led",
     "request": "^2.69.0",
     "serve-favicon": "~2.2.0",
     "singleton-uuid": "^0.1.0",


### PR DESCRIPTION
Use ported raspi-io which uses forked raspi-led to check if led0 is available.
